### PR TITLE
Update portfolio with resume content, new sections, and Framer Motion animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# Portfolio Next.js — Developer Guide
+
+Personal portfolio website for Louis Nguyen, built with Next.js 15, TypeScript, and Tailwind CSS.
+
+## Tech Stack
+
+- **Framework**: Next.js 15.1.3 (App Router, React 19)
+- **Language**: TypeScript (strict)
+- **Styling**: Tailwind CSS v3 with custom dark theme + `tailwindcss-animate`
+- **Animations**: Framer Motion — `whileInView` + `viewport={{ once: true }}` for scroll animations
+- **Icons**: Lucide React
+- **UI primitives**: Shadcn/ui (Button, Input, Textarea) via Radix UI
+- **Contact form**: Formspree endpoint `f/mleagwej`
+- **Fonts**: Poppins (body), Playfair Display (headings/serif)
+
+## Project Structure
+
+```
+src/
+├── app/
+│   ├── layout.tsx        # Root layout — Navbar, SocialLinks, Footer, font vars
+│   ├── page.tsx          # Main page — composes all section components in order
+│   └── globals.css       # Tailwind directives + HSL CSS variable theme (light/dark)
+├── components/
+│   ├── navbar.tsx        # Fixed top nav with mobile hamburger ('use client')
+│   ├── hero.tsx          # Hero section with animated greeting ('use client')
+│   ├── about.tsx         # Profile photo + bio with slide-in animations ('use client')
+│   ├── education.tsx     # Education history cards ('use client')
+│   ├── skills.tsx        # 4-category skill grid with hover lift ('use client')
+│   ├── experience.tsx    # Work experience bullet cards ('use client')
+│   ├── projects.tsx      # Personal projects grid ('use client')
+│   ├── contact.tsx       # Formspree contact form ('use client')
+│   ├── social-links.tsx  # GitHub & LinkedIn icon links
+│   └── ui/
+│       ├── button.tsx    # Shadcn button (CVA variants)
+│       ├── input.tsx     # Shadcn input
+│       └── textarea.tsx  # Shadcn textarea
+└── lib/
+    └── utils.ts          # cn() — clsx + tailwind-merge helper
+```
+
+## Page Sections (in render order)
+
+| Section | Component | Background |
+|---|---|---|
+| Hero | `hero.tsx` | `from-purple-900 via-indigo-900 to-gray-900` gradient |
+| About | `about.tsx` | `bg-gray-800` |
+| Education | `education.tsx` | `bg-gray-900` |
+| Skills | `skills.tsx` | `bg-gray-800` |
+| Experience | `experience.tsx` | `bg-gray-900` |
+| Projects | `projects.tsx` | `bg-gray-800` |
+| Contact | `contact.tsx` | `bg-gray-900` |
+
+Sections intentionally alternate between `gray-800` and `gray-900` for visual separation.
+
+## Animation Patterns
+
+All animated components use `'use client'` and import from `framer-motion`.
+
+- **Hero** — `initial/animate` (visible on load): text fades up with stagger delays
+- **Sections** — `whileInView` + `viewport={{ once: true }}`: triggers once on scroll entry
+- **Cards** — `initial={{ opacity: 0, y: 40 }}` staggered by index (`delay: i * 0.1`)
+- **Experience bullets** — secondary stagger within each card (`delay: i * 0.15 + j * 0.07`)
+- **Skill/Project cards** — `whileHover={{ y: -6 }}` for lift effect
+
+## Development
+
+```bash
+npm run dev    # Dev server with Turbopack (http://localhost:3000)
+npm run build  # Production build — run before deploying
+npm run lint   # ESLint check
+```
+
+## Theming
+
+Dark mode is applied globally via `className="dark"` on `<html>` in `layout.tsx`. Colors are
+HSL CSS variables defined in `globals.css`. The purple accent color is applied directly via
+Tailwind (`text-purple-400`, `bg-purple-600`, etc.) rather than through CSS variables.
+
+## Adding a New Section
+
+1. Create `src/components/my-section.tsx` with `'use client'` and `motion.*` wrappers
+2. Import and render it in `src/app/page.tsx` (maintain alternating bg-gray-800/900 pattern)
+3. Add a nav anchor to the `navItems` array in `src/components/navbar.tsx`
+4. Give the `<section>` an `id` matching the navbar `href`

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-slot": "^1.1.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "lucide-react": "^0.469.0",
         "next": "15.1.3",
         "react": "^19.0.0",
@@ -3457,6 +3458,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4518,6 +4546,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "lucide-react": "^0.469.0",
     "next": "15.1.3",
     "react": "^19.0.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,20 @@
-import { Hero } from '@/components/hero'
-import { About } from '@/components/about'
-import { Skills } from '@/components/skills'
-import { Experience } from '@/components/experience'
-import { Contact } from '@/components/contact'
+import { Hero } from '@/components/hero';
+import { About } from '@/components/about';
+import { Education } from '@/components/education';
+import { Skills } from '@/components/skills';
+import { Experience } from '@/components/experience';
+import { Projects } from '@/components/projects';
+import { Contact } from '@/components/contact';
 
 export default function Home() {
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <Hero />
       <About />
+      <Education />
       <Skills />
       <Experience />
+      <Projects />
       <Contact />
     </div>
   );

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -1,39 +1,60 @@
-import Image from 'next/image'
+'use client';
+
+import Image from 'next/image';
+import { motion } from 'framer-motion';
 
 export function About() {
   return (
     <section id="about" className="py-20 bg-gray-800">
       <div className="container mx-auto px-4">
-        <div className="flex flex-col md:flex-row items-center">
-          <div className="md:w-1/2 mb-8 md:mb-0">
-            <Image
-              src="/myself.jpeg?height=400&width=400"
-              alt="Your Name"
-              width={400}
-              height={400}
-              className="rounded-full shadow-lg"
-            />
-          </div>
-          <div className="md:w-1/2 md:pl-12">
-            <h2 className="text-3xl font-bold mb-4 text-purple-400 font-serif">
-              About Me
-            </h2>
-            <p className="text-gray-300 mb-6 font-light">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif"
+        >
+          About Me
+        </motion.h2>
+        <div className="flex flex-col md:flex-row items-center gap-12">
+          <motion.div
+            initial={{ opacity: 0, x: -50 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.7, ease: 'easeOut' }}
+            className="md:w-1/2 flex justify-center"
+          >
+            <div className="relative">
+              <div className="absolute -inset-4 bg-gradient-to-r from-purple-600 to-indigo-600 rounded-full blur-xl opacity-25" />
+              <Image
+                src="/myself.jpeg"
+                alt="Louis Nguyen"
+                width={350}
+                height={350}
+                className="rounded-full shadow-2xl relative z-10 border-4 border-purple-500/30"
+              />
+            </div>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, x: 50 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.7, ease: 'easeOut', delay: 0.15 }}
+            className="md:w-1/2"
+          >
+            <p className="text-gray-300 mb-6 font-light leading-relaxed text-lg">
               I&apos;m a software engineer passionate about building scalable,
-              data-driven systems and real-time analytics solutions. My
-              expertise spans full-stack development and data engineering, with
-              a growing focus on building efficient data pipelines and
-              infrastructure. I prioritize rapid prototyping, performance
-              optimization, and aligning solutions with business needs—always
-              seeking innovative ways to transform data into actionable
-              insights.
+              data-driven systems and real-time analytics solutions. My expertise
+              spans full-stack development and data engineering, with a focus on
+              building efficient data pipelines and impactful user interfaces. I
+              prioritize rapid prototyping, performance optimization, and aligning
+              solutions with business needs.
             </p>
-            <p className="text-gray-300 font-light">
-              When I&apos;m not coding, you can find me exploring new
-              technologies, staying active, or planning my next travel
-              adventure.
+            <p className="text-gray-300 font-light leading-relaxed text-lg">
+              When I&apos;m not coding, you can find me travelling, playing
+              spikeball, weight training, or catching the latest Marvel movies.
             </p>
-          </div>
+          </motion.div>
         </div>
       </div>
     </section>

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -7,10 +10,22 @@ export function Contact() {
   return (
     <section id="contact" className="py-20 bg-gray-900">
       <div className="container mx-auto px-4">
-        <h2 className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif"
+        >
           Get In Touch
-        </h2>
-        <div className="max-w-2xl mx-auto">
+        </motion.h2>
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.15 }}
+          className="max-w-2xl mx-auto"
+        >
           <form
             action="https://formspree.io/f/mleagwej"
             method="POST"
@@ -56,8 +71,8 @@ export function Contact() {
               </label>
               <Textarea
                 id="message"
+                name="message"
                 required
-                name="message" // This is the field name that Formspree expects
                 placeholder="Your message here..."
                 className="h-32 bg-gray-800 border-gray-700 text-white"
               />
@@ -71,7 +86,7 @@ export function Contact() {
               <Send className="ml-2 h-5 w-5" />
             </Button>
           </form>
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/src/components/education.tsx
+++ b/src/components/education.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { GraduationCap } from 'lucide-react';
+
+const education = [
+  {
+    school: 'University of Wisconsin - Madison',
+    location: 'Madison, WI',
+    degree: 'Bachelor of Science in Computer Science and Data Science',
+    period: 'Sep 2020 – May 2024',
+    details: [
+      'GPA: 3.53 / 4.0',
+      'Awards: Mercile J. Lee Scholarship, Thermo Fisher Scientific STEM Scholarship',
+      'Relevant Coursework: Programming I–IV, Data Structures & Algorithms, Computer Organization, Data Modeling, Artificial Intelligence',
+    ],
+  },
+  {
+    school: 'National University of Singapore',
+    location: 'Singapore',
+    degree: 'University of Wisconsin Singapore Study Abroad Program',
+    period: 'Jan 2023 – May 2023',
+    details: [],
+  },
+];
+
+export function Education() {
+  return (
+    <section id="education" className="py-20 bg-gray-900">
+      <div className="container mx-auto px-4">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif"
+        >
+          Education
+        </motion.h2>
+        <div className="max-w-3xl mx-auto space-y-6">
+          {education.map((edu, i) => (
+            <motion.div
+              key={edu.school}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6, delay: i * 0.15 }}
+              className="bg-gray-800 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
+            >
+              <div className="flex items-start gap-4">
+                <div className="bg-purple-600/20 p-3 rounded-lg mt-1 flex-shrink-0">
+                  <GraduationCap className="text-purple-400 h-6 w-6" />
+                </div>
+                <div className="flex-1">
+                  <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 mb-1">
+                    <h3 className="text-xl font-semibold text-white">{edu.school}</h3>
+                    <span className="text-sm text-gray-400 whitespace-nowrap">{edu.period}</span>
+                  </div>
+                  <p className="text-purple-400 font-medium mb-1">{edu.degree}</p>
+                  <p className="text-gray-500 text-sm mb-3">{edu.location}</p>
+                  {edu.details.length > 0 && (
+                    <ul className="space-y-1">
+                      {edu.details.map((detail) => (
+                        <li
+                          key={detail}
+                          className="text-gray-400 text-sm font-light flex items-start gap-2"
+                        >
+                          <span className="text-purple-500 mt-1 flex-shrink-0">•</span>
+                          {detail}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -1,44 +1,90 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Briefcase } from 'lucide-react';
+
 const experiences = [
   {
     company: 'Expedia Group',
-    position: 'Software Engineer',
-    period: '2024 - Present',
-    description:
-      'I design event-driven architectures using Kotlin, Python, and Kafka to enable real-time data streaming, while optimizing ETL pipelines with Scala, Apache Spark, and AWS EMR for large-scale data processing. I create modular, reusable React.js components for dynamic data visualization, integrating them with APIs in TypeScript and Node.js. My work also includes optimizing SQL queries to improve database performance and enhance data retrieval. I monitor system performance with tools like AWS CloudWatch, Datadog, and Splunk, and streamline deployments by automating CI/CD pipelines. I collaborate closely with stakeholders to ensure technical solutions align with business objectives and deliver meaningful outcomes.',
-  },
-  {
-    company: 'University of Wisconsin - Madison',
-    position: 'Computer Science Tutor',
-    period: '2023 - 2024',
-    description:
-      'I tutored students in Java and Python, breaking down complex concepts and customizing lessons to meet individual learning needs. I fostered a supportive and engaging environment, helping students build a strong foundation in Computer Science and Data Science.',
+    location: 'Seattle, WA',
+    position: 'Software Engineering Intern',
+    period: 'May 2023 – Jul 2023',
+    bullets: [
+      'Collaborated in a team of 15+ engineers to develop a high-performance real-time data analytics dashboard, cutting AWS costs by 75%.',
+      'Implemented GraphQL schemas and resolvers for frontend-backend communication to ensure efficient and accurate data transfer.',
+      'Optimized SQL queries within the Apache Druid database to reduce dashboard latency by over 60% (from >3s to <1s).',
+      'Created modular React.js components for interactive dashboard tiles to support an intuitive user interface and clear data visualization.',
+    ],
   },
   {
     company: 'Thomson Reuters',
-    position: 'Software Engineer Intern',
-    period: '2021 - 2022',
-    description:
-      'I worked as a Frontend Web Developer in an agile team focused on developing static content for a cloud-based legal research web application. I enhanced the frontend UI using React.js and JQuery while modernizing legacy code to improve performance and ensure Web Accessibility compliance. Throughout the software design cycle, I gained experience in issue tracking, code review, development environments, and unit testing. I also collaborated with UX and accessibility teams to strategically plan code design, optimizing both user experience and accessibility standards.',
+    location: 'Minneapolis, MN',
+    position: 'Software Engineering Intern',
+    period: 'May 2022 – Aug 2022',
+    bullets: [
+      'Worked in an agile team that concentrated on developing static content for a cloud-based legal research web application.',
+      'Enhanced Frontend UI using React.js and jQuery while modernizing legacy code and ensuring Web Accessibility support.',
+      'Gained exposure to the software design cycle including issue tracking, code review, development environments, and unit testing.',
+      'Coordinated with UX and accessibility teams to strategically plan code design, optimizing user experience and accessibility standards.',
+    ],
   },
 ];
 
 export function Experience() {
   return (
-    <section id="experience" className="py-20 bg-gray-800">
+    <section id="experience" className="py-20 bg-gray-900">
       <div className="container mx-auto px-4">
-        <h2 className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif">Work Experience</h2>
-        <div className="space-y-12">
-          {experiences.map((exp, index) => (
-            <div key={index} className="bg-gray-900 p-6 rounded-lg shadow-md">
-              <h3 className="text-xl font-semibold mb-2 text-white">{exp.position}</h3>
-              <p className="text-purple-400 mb-2 font-light">{exp.company} | {exp.period}</p>
-              <p className="text-gray-400 mb-4 font-light">{exp.description}</p>
-            </div>
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif"
+        >
+          Work Experience
+        </motion.h2>
+        <div className="max-w-3xl mx-auto space-y-6">
+          {experiences.map((exp, i) => (
+            <motion.div
+              key={exp.company}
+              initial={{ opacity: 0, x: -40 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6, delay: i * 0.15 }}
+              className="bg-gray-800 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
+            >
+              <div className="flex items-start gap-4">
+                <div className="bg-purple-600/20 p-3 rounded-lg mt-1 flex-shrink-0">
+                  <Briefcase className="text-purple-400 h-6 w-6" />
+                </div>
+                <div className="flex-1">
+                  <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 mb-1">
+                    <h3 className="text-xl font-semibold text-white">{exp.position}</h3>
+                    <span className="text-sm text-gray-400 whitespace-nowrap">{exp.period}</span>
+                  </div>
+                  <p className="text-purple-400 font-medium mb-1">{exp.company}</p>
+                  <p className="text-gray-500 text-sm mb-4">{exp.location}</p>
+                  <ul className="space-y-2">
+                    {exp.bullets.map((bullet, j) => (
+                      <motion.li
+                        key={j}
+                        initial={{ opacity: 0, x: -10 }}
+                        whileInView={{ opacity: 1, x: 0 }}
+                        viewport={{ once: true }}
+                        transition={{ duration: 0.4, delay: i * 0.15 + j * 0.07 }}
+                        className="text-gray-400 text-sm font-light flex items-start gap-2"
+                      >
+                        <span className="text-purple-500 mt-1 flex-shrink-0">•</span>
+                        {bullet}
+                      </motion.li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </motion.div>
           ))}
-        </div>
-        <div className="text-center mt-12">
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,19 +1,78 @@
+'use client';
 
+import { motion } from 'framer-motion';
 
 export function Hero() {
   return (
-    <section className="bg-gradient-to-r from-purple-900 to-indigo-900 text-white py-20 min-h-[10vh] flex items-center justify-center">
-      <div className="container mx-auto px-4">
+    <section className="bg-gradient-to-br from-purple-900 via-indigo-900 to-gray-900 text-white py-32 min-h-[60vh] flex items-center justify-center relative overflow-hidden">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -right-40 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-indigo-500/10 rounded-full blur-3xl" />
+      </div>
+
+      <div className="container mx-auto px-4 relative z-10">
         <div className="max-w-3xl mx-auto text-center">
-          <h1 className="text-4xl md:text-6xl font-bold mb-6 font-serif">
-            Hi, I&apos;m Louis
-          </h1>
-          <p className="text-xl md:text-2xl mb-8 font-light">
-            A curious Software Engineer that likes <br />
-            to build things and solve complex problems
-          </p>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+            className="text-purple-400 text-lg font-medium mb-4 tracking-widest uppercase"
+          >
+            Hello, World!
+          </motion.p>
+          <motion.h1
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, ease: 'easeOut', delay: 0.15 }}
+            className="text-5xl md:text-7xl font-bold mb-6 font-serif"
+          >
+            I&apos;m Louis Nguyen
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, ease: 'easeOut', delay: 0.3 }}
+            className="text-xl md:text-2xl mb-10 font-light text-gray-300"
+          >
+            Software Engineer passionate about building scalable systems and{' '}
+            <span className="text-purple-400">transforming data into insights</span>
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, ease: 'easeOut', delay: 0.45 }}
+            className="flex flex-wrap gap-x-4 gap-y-2 justify-center text-sm text-gray-400"
+          >
+            <span>louishguyen01@hotmail.com</span>
+            <span className="hidden sm:inline text-gray-600">·</span>
+            <span>651-269-5551</span>
+            <span className="hidden sm:inline text-gray-600">·</span>
+            <a
+              href="https://louisnguyen.me"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-purple-400 hover:text-purple-300 transition-colors"
+            >
+              louisnguyen.me
+            </a>
+          </motion.div>
         </div>
       </div>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1, duration: 0.5 }}
+        className="absolute bottom-8 left-1/2 -translate-x-1/2"
+      >
+        <motion.div
+          animate={{ y: [0, 8, 0] }}
+          transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+          className="w-6 h-10 border-2 border-purple-400/50 rounded-full flex justify-center pt-2"
+        >
+          <div className="w-1 h-2 bg-purple-400/70 rounded-full" />
+        </motion.div>
+      </motion.div>
     </section>
   );
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -7,8 +7,10 @@ import { Menu, X } from 'lucide-react';
 
 const navItems = [
   { name: 'About', href: '#about' },
+  { name: 'Education', href: '#education' },
   { name: 'Skills', href: '#skills' },
   { name: 'Experience', href: '#experience' },
+  { name: 'Projects', href: '#projects' },
   { name: 'Contact', href: '#contact' },
 ];
 

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -1,47 +1,91 @@
-import Image from 'next/image'
-import { Button } from "@/components/ui/button"
-import { ArrowRight } from 'lucide-react'
+'use client';
+
+import { motion } from 'framer-motion';
 
 const projects = [
-  { name: "Project 1", description: "A brief description of Project 1", image: "/placeholder.svg?height=300&width=400" },
-  { name: "Project 2", description: "A brief description of Project 2", image: "/placeholder.svg?height=300&width=400" },
-  { name: "Project 3", description: "A brief description of Project 3", image: "/placeholder.svg?height=300&width=400" },
-]
+  {
+    name: 'Spotify Playlist Sync',
+    subtitle: 'Playlist Synchronization Tool',
+    period: 'Jan 2023 – Jul 2023',
+    tech: ['React.js', 'TypeScript', 'Spotify API', 'Firebase', 'Firestore'],
+    bullets: [
+      "Developed a React.js web app with TypeScript, utilizing Spotify's API for user authentication and playlist comparison.",
+      'Employed Google Firebase and Firestore to seamlessly deploy, host, and securely store data for the web application.',
+    ],
+  },
+  {
+    name: "Wolfram's Cellular Automata",
+    subtitle: 'Complex Pattern Generator',
+    period: 'Feb 2022 – Jun 2022',
+    tech: ['Python', 'NumPy', 'Matplotlib', 'Flask', 'Heroku'],
+    bullets: [
+      "Wrote a program in Python using NumPy and Matplotlib that visually generated Wolfram's cellular automata.",
+      'Packaged the program into a web application using the Flask framework and hosted it on the Heroku Cloud Platform.',
+    ],
+  },
+  {
+    name: 'Cryptocurrency Trading Bot',
+    subtitle: 'Automated Trading Software',
+    period: 'May 2021 – Aug 2022',
+    tech: ['Node.js', 'WebSocket', 'Coinbase API'],
+    bullets: [
+      'Designed a cryptocurrency trading algorithm that initiates trades when specified price targets are hit.',
+      'Utilized Node.js to build the bot and establish a WebSocket connection to the Coinbase API to retrieve real-time market data.',
+    ],
+  },
+];
 
 export function Projects() {
   return (
-    <section className="py-20 bg-white">
+    <section id="projects" className="py-20 bg-gray-800">
       <div className="container mx-auto px-4">
-        <h2 className="text-3xl font-bold text-center mb-12">Featured Projects</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {projects.map((project) => (
-            <div key={project.name} className="bg-gray-100 rounded-lg overflow-hidden shadow-md">
-              <Image
-                src={project.image}
-                alt={project.name}
-                width={400}
-                height={300}
-                className="w-full h-48 object-cover"
-              />
-              <div className="p-6">
-                <h3 className="text-xl font-semibold mb-2">{project.name}</h3>
-                <p className="text-gray-600 mb-4">{project.description}</p>
-                <Button variant="outline">
-                  View Project
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Button>
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif"
+        >
+          Projects
+        </motion.h2>
+        <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {projects.map((project, i) => (
+            <motion.div
+              key={project.name}
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: i * 0.12 }}
+              whileHover={{ y: -6, transition: { duration: 0.2 } }}
+              className="bg-gray-900 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300 flex flex-col"
+            >
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold text-white mb-1">{project.name}</h3>
+                <p className="text-purple-400 text-sm font-medium mb-1">{project.subtitle}</p>
+                <p className="text-gray-500 text-xs mb-4">{project.period}</p>
+                <ul className="space-y-2 mb-4">
+                  {project.bullets.map((bullet, j) => (
+                    <li key={j} className="text-gray-400 text-sm font-light flex items-start gap-2">
+                      <span className="text-purple-500 mt-1 flex-shrink-0">•</span>
+                      {bullet}
+                    </li>
+                  ))}
+                </ul>
               </div>
-            </div>
+              <div className="flex flex-wrap gap-2 mt-auto pt-2">
+                {project.tech.map((t) => (
+                  <span
+                    key={t}
+                    className="text-xs font-medium bg-gray-800 text-gray-300 px-2 py-1 rounded-md border border-gray-700"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </motion.div>
           ))}
-        </div>
-        <div className="text-center mt-12">
-          <Button size="lg">
-            View All Projects
-            <ArrowRight className="ml-2 h-5 w-5" />
-          </Button>
         </div>
       </div>
     </section>
-  )
+  );
 }
-

--- a/src/components/skills.tsx
+++ b/src/components/skills.tsx
@@ -1,49 +1,70 @@
-import { Code, Database, Server, Cloudy } from 'lucide-react';
+'use client';
+
+import { motion } from 'framer-motion';
+import { Code, Database, Server, Wrench } from 'lucide-react';
 
 const skills = [
   {
     name: 'Frontend Development',
     icon: Code,
-    description: 'HTML, CSS, TypeScript, JavaScript, React.js, Next.js',
+    items: ['HTML', 'CSS', 'TypeScript', 'JavaScript', 'React.js', 'Next.js'],
   },
   {
     name: 'Backend Development',
     icon: Server,
-    description:
-      'Java, Python, Node.js, Flask, Spring Boot, GraphQL, RESTful, Microservices',
+    items: ['Java', 'Python', 'C', 'Node.js', 'Flask', 'GraphQL', 'RESTful APIs'],
   },
   {
-    name: 'Big Data',
+    name: 'Data & Analytics',
     icon: Database,
-    description: 'Kotlin, Scala, Kafka, Spark, ETL, SQL, R, Apache Druid',
+    items: ['SQL', 'R', 'Apache Druid', 'Kafka', 'Spark', 'ETL Pipelines'],
   },
   {
-    name: 'Cloud/Deployment',
-    icon: Cloudy,
-    description:
-      'AWS, Docker, Serverless, CI/CD, GitHub Actions, Spinnaker, Jenkins, Datadog, Splunk, Firebase, Git',
+    name: 'Tools & Cloud',
+    icon: Wrench,
+    items: ['AWS', 'Firebase', 'Docker', 'Git', 'CI/CD', 'Unix', 'VS Code'],
   },
 ];
 
 export function Skills() {
   return (
-    <section id="skills" className="py-20 bg-gray-900">
+    <section id="skills" className="py-20 bg-gray-800">
       <div className="container mx-auto px-4">
-        <h2 className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif">
-          My Skills
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-          {skills.map((skill) => (
-            <div
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif"
+        >
+          Skills
+        </motion.h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {skills.map((skill, i) => (
+            <motion.div
               key={skill.name}
-              className="bg-gray-800 p-6 rounded-lg shadow-md"
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+              whileHover={{ y: -6, transition: { duration: 0.2 } }}
+              className="bg-gray-900 p-6 rounded-xl shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
             >
-              <skill.icon className="h-12 w-12 text-purple-500 mb-4" />
-              <h3 className="text-xl font-semibold mb-2 text-white">
-                {skill.name}
-              </h3>
-              <p className="text-gray-400 font-light">{skill.description}</p>
-            </div>
+              <div className="bg-purple-600/20 p-3 rounded-lg w-fit mb-4">
+                <skill.icon className="h-6 w-6 text-purple-400" />
+              </div>
+              <h3 className="text-lg font-semibold mb-4 text-white">{skill.name}</h3>
+              <div className="flex flex-wrap gap-2">
+                {skill.items.map((item) => (
+                  <span
+                    key={item}
+                    className="text-xs font-medium bg-gray-800 text-gray-300 px-2 py-1 rounded-md border border-gray-700"
+                  >
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </motion.div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
- Add Education section (UW-Madison BS CS & Data Science, NUS study abroad)
- Fix Experience data to match resume: Expedia Group internship (May–Jul 2023)
  and Thomson Reuters internship (May–Aug 2022) with accurate bullet points;
  remove stale UW-Madison tutor entry that was not on resume
- Replace placeholder Projects with real data: Spotify Playlist Sync,
  Wolfram's Cellular Automata, Cryptocurrency Trading Bot
- Update Skills section into 4 clean categories matching resume tech stack
- Update navbar with Education and Projects anchor links
- Add Framer Motion animations: hero fade-up on load, scroll-triggered
  whileInView on all sections, staggered card entrances, hover-lift on cards
- Update Hero with contact info, scroll indicator, and decorative blurs
- Add CLAUDE.md developer guide documenting architecture and patterns
- Remove dead code (empty div in experience, placeholder image imports)

https://claude.ai/code/session_01NJjGMfZGiQjf5z8NEQfjSB