### PR TITLE
Update resume content, add Certifications section, fix mobile nav

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Hero } from '@/components/hero';
 import { About } from '@/components/about';
 import { Education } from '@/components/education';
+import { Certifications } from '@/components/certifications';
 import { Skills } from '@/components/skills';
 import { Experience } from '@/components/experience';
 import { Projects } from '@/components/projects';
@@ -12,6 +13,7 @@ export default function Home() {
       <Hero />
       <About />
       <Education />
+      <Certifications />
       <Skills />
       <Experience />
       <Projects />

--- a/src/components/certifications.tsx
+++ b/src/components/certifications.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { BadgeCheck } from 'lucide-react';
+
+const certifications = [
+  {
+    name: 'AWS Certified Solutions Architect – Associate',
+    issuer: 'Amazon Web Services',
+    location: 'Seattle, WA',
+    period: 'Jan 2025 – Jan 2028',
+    description: 'Validated expertise in AWS cloud architecture, services, and best practices.',
+  },
+];
+
+export function Certifications() {
+  return (
+    <section id="certifications" className="py-20 bg-gray-800">
+      <div className="container mx-auto px-4">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl font-bold text-center mb-12 text-purple-400 font-serif"
+        >
+          Certifications
+        </motion.h2>
+        <div className="max-w-3xl mx-auto space-y-6">
+          {certifications.map((cert, i) => (
+            <motion.div
+              key={cert.name}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6, delay: i * 0.15 }}
+              className="bg-gray-900 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
+            >
+              <div className="flex items-start gap-4">
+                <div className="bg-purple-600/20 p-3 rounded-lg mt-1 flex-shrink-0">
+                  <BadgeCheck className="text-purple-400 h-6 w-6" />
+                </div>
+                <div className="flex-1">
+                  <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 mb-1">
+                    <h3 className="text-xl font-semibold text-white">{cert.name}</h3>
+                    <span className="text-sm text-gray-400 whitespace-nowrap">{cert.period}</span>
+                  </div>
+                  <p className="text-purple-400 font-medium mb-1">{cert.issuer}</p>
+                  <p className="text-gray-500 text-sm mb-3">{cert.location}</p>
+                  <p className="text-gray-400 text-sm font-light">{cert.description}</p>
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -8,7 +8,7 @@ import { Send } from 'lucide-react';
 
 export function Contact() {
   return (
-    <section id="contact" className="py-20 bg-gray-900">
+    <section id="contact" className="py-20 bg-gray-800">
       <div className="container mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -43,7 +43,7 @@ export function Contact() {
                 name="name"
                 required
                 placeholder="Your Name"
-                className="bg-gray-800 border-gray-700 text-white"
+                className="bg-gray-900 border-gray-700 text-white"
               />
             </div>
             <div>
@@ -59,7 +59,7 @@ export function Contact() {
                 type="email"
                 required
                 placeholder="your@email.com"
-                className="bg-gray-800 border-gray-700 text-white"
+                className="bg-gray-900 border-gray-700 text-white"
               />
             </div>
             <div>
@@ -74,7 +74,7 @@ export function Contact() {
                 name="message"
                 required
                 placeholder="Your message here..."
-                className="h-32 bg-gray-800 border-gray-700 text-white"
+                className="h-32 bg-gray-900 border-gray-700 text-white"
               />
             </div>
             <Button

--- a/src/components/education.tsx
+++ b/src/components/education.tsx
@@ -7,20 +7,13 @@ const education = [
   {
     school: 'University of Wisconsin - Madison',
     location: 'Madison, WI',
-    degree: 'Bachelor of Science in Computer Science and Data Science',
-    period: 'Sep 2020 – May 2024',
+    degree: 'Bachelor of Science in Computer Science, Data Science',
+    period: 'Aug 2020 – May 2024',
     details: [
-      'GPA: 3.53 / 4.0',
-      'Awards: Mercile J. Lee Scholarship, Thermo Fisher Scientific STEM Scholarship',
-      'Relevant Coursework: Programming I–IV, Data Structures & Algorithms, Computer Organization, Data Modeling, Artificial Intelligence',
+      'GPA: 3.6 / 4.0',
+      'Relevant Coursework: Data Structures & Algorithms, Computer Organization, Data Modeling, AI',
+      'Extracurriculars: Theta Tau Engineering Fraternity, Vietnamese Student Association, Web Development Club',
     ],
-  },
-  {
-    school: 'National University of Singapore',
-    location: 'Singapore',
-    degree: 'University of Wisconsin Singapore Study Abroad Program',
-    period: 'Jan 2023 – May 2023',
-    details: [],
   },
 ];
 
@@ -58,19 +51,17 @@ export function Education() {
                   </div>
                   <p className="text-purple-400 font-medium mb-1">{edu.degree}</p>
                   <p className="text-gray-500 text-sm mb-3">{edu.location}</p>
-                  {edu.details.length > 0 && (
-                    <ul className="space-y-1">
-                      {edu.details.map((detail) => (
-                        <li
-                          key={detail}
-                          className="text-gray-400 text-sm font-light flex items-start gap-2"
-                        >
-                          <span className="text-purple-500 mt-1 flex-shrink-0">•</span>
-                          {detail}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <ul className="space-y-1">
+                    {edu.details.map((detail) => (
+                      <li
+                        key={detail}
+                        className="text-gray-400 text-sm font-light flex items-start gap-2"
+                      >
+                        <span className="text-purple-500 mt-1 flex-shrink-0">•</span>
+                        {detail}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               </div>
             </motion.div>

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -7,32 +7,57 @@ const experiences = [
   {
     company: 'Expedia Group',
     location: 'Seattle, WA',
-    position: 'Software Engineering Intern',
+    position: 'Software Engineer II',
+    period: 'Aug 2024 – Present',
+    bullets: [
+      'Led the development of a streaming pipeline using Kotlin Spring Boot, Apache Kafka and Cassandra, processing 5M+ events daily for 200+ lodging partners, enabling real-time analytics and performance monitoring.',
+      'Directed a group of vendor engineers to migrate legacy analytical dashboards to in-house real-time dashboards, reducing load times from 30s to 3s.',
+      'Optimized Apache Druid SQL queries by 80% (from 5s to 1s average query time), improving OLAP performance for business analytics.',
+      'Identified a major manual bottleneck in the UI deployment process and automated release scripts with Python, saving 10+ hours per week and reducing deployment failures by 70%.',
+      'Maintained and improved batch ETL workflows with Apache Spark (Scala) and Airflow, enhancing data accuracy and freshness for downstream reporting used by 50+ stakeholders.',
+      'Set up monitoring and alerting with Datadog and Splunk, ensuring 99.9% availability and data integrity.',
+      'Coordinated with 4 cross-geo engineering teams to align API contracts and data schemas.',
+      'Mentored an engineering intern in developing a Node.js Lambda notification scheduler that automated configurable stakeholder reminders via email and messaging.',
+      'Analyzed 5TB+ of historical data in Apache Iceberg data lake via Querybook, identifying data quality issues affecting 50% of customer operations reports and implementing validation fixes.',
+    ],
+  },
+  {
+    company: 'University of Wisconsin - Madison',
+    location: 'Madison, WI',
+    position: 'Computer Science Tutor',
+    period: 'Sep 2023 – May 2024',
+    bullets: [
+      'Provided one-on-one and group tutoring in Java and Python, improving students\' problem-solving skills.',
+      'Assisted students with debugging, unit testing, and code reviews, reinforcing best coding practices.',
+    ],
+  },
+  {
+    company: 'Expedia Group',
+    location: 'Seattle, WA',
+    position: 'Software Engineer Intern',
     period: 'May 2023 – Jul 2023',
     bullets: [
-      'Collaborated in a team of 15+ engineers to develop a high-performance real-time data analytics dashboard, cutting AWS costs by 75%.',
-      'Implemented GraphQL schemas and resolvers for frontend-backend communication to ensure efficient and accurate data transfer.',
-      'Optimized SQL queries within the Apache Druid database to reduce dashboard latency by over 60% (from >3s to <1s).',
-      'Created modular React.js components for interactive dashboard tiles to support an intuitive user interface and clear data visualization.',
+      'Built real-time analytics dashboards in React.js and TypeScript with responsive, data-driven visualizations.',
+      'Developed GraphQL APIs in Node.js to serve analytics data, enabling efficient access across frontend applications.',
+      'Implemented reusable and modular UI components improving code maintainability and developer productivity.',
     ],
   },
   {
     company: 'Thomson Reuters',
     location: 'Minneapolis, MN',
-    position: 'Software Engineering Intern',
+    position: 'Software Engineer Intern',
     period: 'May 2022 – Aug 2022',
     bullets: [
-      'Worked in an agile team that concentrated on developing static content for a cloud-based legal research web application.',
-      'Enhanced Frontend UI using React.js and jQuery while modernizing legacy code and ensuring Web Accessibility support.',
-      'Gained exposure to the software design cycle including issue tracking, code review, development environments, and unit testing.',
-      'Coordinated with UX and accessibility teams to strategically plan code design, optimizing user experience and accessibility standards.',
+      'Enhanced UI/UX by modernizing a React.js and JavaScript frontend, improving accessibility and usability.',
+      'Gained exposure to Agile development methodologies, conducting code reviews and unit testing.',
+      'Refactored legacy jQuery code into React.js components, reducing technical debt and improving maintainability.',
     ],
   },
 ];
 
 export function Experience() {
   return (
-    <section id="experience" className="py-20 bg-gray-900">
+    <section id="experience" className="py-20 bg-gray-800">
       <div className="container mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -46,12 +71,12 @@ export function Experience() {
         <div className="max-w-3xl mx-auto space-y-6">
           {experiences.map((exp, i) => (
             <motion.div
-              key={exp.company}
+              key={`${exp.company}-${exp.period}`}
               initial={{ opacity: 0, x: -40 }}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true }}
-              transition={{ duration: 0.6, delay: i * 0.15 }}
-              className="bg-gray-800 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
+              transition={{ duration: 0.6, delay: i * 0.1 }}
+              className="bg-gray-900 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
             >
               <div className="flex items-start gap-4">
                 <div className="bg-purple-600/20 p-3 rounded-lg mt-1 flex-shrink-0">
@@ -71,7 +96,7 @@ export function Experience() {
                         initial={{ opacity: 0, x: -10 }}
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
-                        transition={{ duration: 0.4, delay: i * 0.15 + j * 0.07 }}
+                        transition={{ duration: 0.4, delay: i * 0.1 + j * 0.05 }}
                         className="text-gray-400 text-sm font-light flex items-start gap-2"
                       >
                         <span className="text-purple-500 mt-1 flex-shrink-0">•</span>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -43,17 +43,22 @@ export function Hero() {
             transition={{ duration: 0.5, ease: 'easeOut', delay: 0.45 }}
             className="flex flex-wrap gap-x-4 gap-y-2 justify-center text-sm text-gray-400"
           >
-            <span>louishguyen01@hotmail.com</span>
-            <span className="hidden sm:inline text-gray-600">·</span>
-            <span>651-269-5551</span>
-            <span className="hidden sm:inline text-gray-600">·</span>
             <a
-              href="https://louisnguyen.me"
+              href="https://www.linkedin.com/in/nguyen2001"
               target="_blank"
               rel="noopener noreferrer"
               className="text-purple-400 hover:text-purple-300 transition-colors"
             >
-              louisnguyen.me
+              LinkedIn
+            </a>
+            <span className="hidden sm:inline text-gray-600">·</span>
+            <a
+              href="https://louiethedev.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-purple-400 hover:text-purple-300 transition-colors"
+            >
+              louiethedev.com
             </a>
           </motion.div>
         </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -8,6 +8,7 @@ import { Menu, X } from 'lucide-react';
 const navItems = [
   { name: 'About', href: '#about' },
   { name: 'Education', href: '#education' },
+  { name: 'Certifications', href: '#certifications' },
   { name: 'Skills', href: '#skills' },
   { name: 'Experience', href: '#experience' },
   { name: 'Projects', href: '#projects' },

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -19,7 +19,7 @@ export function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <header className="bg-gray-800 shadow-sm fixed w-full z-10">
+    <header className="bg-gray-800 shadow-sm fixed w-full z-50">
       <div className="container mx-auto px-4">
         <div className="flex justify-between items-center py-4">
           <Link
@@ -57,7 +57,7 @@ export function Navbar() {
 
       {/* Mobile menu */}
       {isOpen && (
-        <nav className="md:hidden">
+        <nav className="md:hidden bg-gray-800 border-t border-gray-700 shadow-lg">
           <ul className="flex flex-col items-center py-4">
             {navItems.map((item) => (
               <li key={item.name} className="w-full">

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -37,7 +37,7 @@ const projects = [
 
 export function Projects() {
   return (
-    <section id="projects" className="py-20 bg-gray-800">
+    <section id="projects" className="py-20 bg-gray-900">
       <div className="container mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -57,7 +57,7 @@ export function Projects() {
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.12 }}
               whileHover={{ y: -6, transition: { duration: 0.2 } }}
-              className="bg-gray-900 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300 flex flex-col"
+              className="bg-gray-800 rounded-xl p-6 shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300 flex flex-col"
             >
               <div className="flex-1">
                 <h3 className="text-lg font-semibold text-white mb-1">{project.name}</h3>
@@ -76,7 +76,7 @@ export function Projects() {
                 {project.tech.map((t) => (
                   <span
                     key={t}
-                    className="text-xs font-medium bg-gray-800 text-gray-300 px-2 py-1 rounded-md border border-gray-700"
+                    className="text-xs font-medium bg-gray-700 text-gray-300 px-2 py-1 rounded-md border border-gray-600"
                   >
                     {t}
                   </span>

--- a/src/components/skills.tsx
+++ b/src/components/skills.tsx
@@ -1,34 +1,34 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Code, Database, Server, Wrench } from 'lucide-react';
+import { Code, Database, Server, Cloud } from 'lucide-react';
 
 const skills = [
   {
-    name: 'Frontend Development',
+    name: 'Languages',
     icon: Code,
-    items: ['HTML', 'CSS', 'TypeScript', 'JavaScript', 'React.js', 'Next.js'],
+    items: ['Java', 'JavaScript', 'Python', 'Kotlin', 'Scala', 'HTML', 'CSS', 'SQL', 'C', 'R', 'TypeScript'],
   },
   {
-    name: 'Backend Development',
+    name: 'Technologies',
     icon: Server,
-    items: ['Java', 'Python', 'C', 'Node.js', 'Flask', 'GraphQL', 'RESTful APIs'],
+    items: ['React.js', 'Next.js', 'Node.js', 'Flask', 'GraphQL', 'Spring Boot', 'Microservices', 'Kafka', 'Spark', 'RESTful', 'ETL'],
   },
   {
-    name: 'Data & Analytics',
+    name: 'Databases',
     icon: Database,
-    items: ['SQL', 'R', 'Apache Druid', 'Kafka', 'Spark', 'ETL Pipelines'],
+    items: ['MySQL', 'PostgreSQL', 'Hive', 'ScyllaDB', 'Apache Druid', 'MongoDB', 'S3'],
   },
   {
-    name: 'Tools & Cloud',
-    icon: Wrench,
-    items: ['AWS', 'Firebase', 'Docker', 'Git', 'CI/CD', 'Unix', 'VS Code'],
+    name: 'Cloud & DevOps',
+    icon: Cloud,
+    items: ['AWS', 'Docker', 'Serverless', 'CI/CD', 'GitHub Actions', 'Spinnaker', 'Jenkins', 'Datadog', 'Splunk'],
   },
 ];
 
 export function Skills() {
   return (
-    <section id="skills" className="py-20 bg-gray-800">
+    <section id="skills" className="py-20 bg-gray-900">
       <div className="container mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -48,7 +48,7 @@ export function Skills() {
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
               whileHover={{ y: -6, transition: { duration: 0.2 } }}
-              className="bg-gray-900 p-6 rounded-xl shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
+              className="bg-gray-800 p-6 rounded-xl shadow-lg border border-gray-700 hover:border-purple-500/50 transition-colors duration-300"
             >
               <div className="bg-purple-600/20 p-3 rounded-lg w-fit mb-4">
                 <skill.icon className="h-6 w-6 text-purple-400" />
@@ -58,7 +58,7 @@ export function Skills() {
                 {skill.items.map((item) => (
                   <span
                     key={item}
-                    className="text-xs font-medium bg-gray-800 text-gray-300 px-2 py-1 rounded-md border border-gray-700"
+                    className="text-xs font-medium bg-gray-700 text-gray-300 px-2 py-1 rounded-md border border-gray-600"
                   >
                     {item}
                   </span>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,12 +23,26 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@/styles/*": ["styles/*"],
-      "@/components/*": ["components/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@/styles/*": [
+        "styles/*"
+      ],
+      "@/components/*": [
+        "components/*"
+      ]
     },
-    "baseUrl": "src/",
+    "baseUrl": "src/"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- **Resume content**: Updated Experience (4 roles: Expedia SWE II Aug 2024–Present, UW-Madison Tutor, Expedia Intern, Thomson Reuters Intern), Education (GPA 3.6/4.0, updated extracurriculars, removed NUS), and Skills (reorganised into Languages / Technologies / Databases / Cloud & DevOps)
- **Certifications section**: New section added for AWS Certified Solutions Architect – Associate (Jan 2025–Jan 2028), included in navbar and page
- **Hero**: Removed email and phone number to prevent bot scraping; shows LinkedIn and louiethedev.com only
- **Mobile nav fix**: Increased header `z-index` from `z-10` → `z-50` and added explicit `bg-gray-800` background to the mobile dropdown so it no longer renders behind page content

## Test plan

- [ ] Verify all 4 experience entries display correctly with accurate dates and bullets
- [ ] Verify Education shows GPA 3.6/4.0 and updated extracurriculars
- [ ] Verify Certifications section appears between Education and Skills in the navbar and on the page
- [ ] Verify Hero shows LinkedIn + louiethedev.com only (no email/phone)
- [ ] On mobile, open hamburger menu and confirm dropdown is fully opaque and readable over any section

https://claude.ai/code/session_01NJjGMfZGiQjf5z8NEQfjSB