### PR TITLE
Update about hobbies text and add per-company experience icons

### DIFF
--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -52,7 +52,7 @@ export function About() {
             </p>
             <p className="text-gray-300 font-light leading-relaxed text-lg">
               When I&apos;m not coding, you can find me travelling, playing
-              spikeball, weight training, or catching the latest Marvel movies.
+              spikeball, weight training, or reading up about credit cards.
             </p>
           </motion.div>
         </div>

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Briefcase } from 'lucide-react';
+import { Globe, BookOpen, BarChart2, Scale } from 'lucide-react';
 
 const experiences = [
   {
     company: 'Expedia Group',
+    icon: Globe,
     location: 'Seattle, WA',
     position: 'Software Engineer II',
     period: 'Aug 2024 – Present',
@@ -23,6 +24,7 @@ const experiences = [
   },
   {
     company: 'University of Wisconsin - Madison',
+    icon: BookOpen,
     location: 'Madison, WI',
     position: 'Computer Science Tutor',
     period: 'Sep 2023 – May 2024',
@@ -33,6 +35,7 @@ const experiences = [
   },
   {
     company: 'Expedia Group',
+    icon: BarChart2,
     location: 'Seattle, WA',
     position: 'Software Engineer Intern',
     period: 'May 2023 – Jul 2023',
@@ -44,6 +47,7 @@ const experiences = [
   },
   {
     company: 'Thomson Reuters',
+    icon: Scale,
     location: 'Minneapolis, MN',
     position: 'Software Engineer Intern',
     period: 'May 2022 – Aug 2022',
@@ -80,7 +84,7 @@ export function Experience() {
             >
               <div className="flex items-start gap-4">
                 <div className="bg-purple-600/20 p-3 rounded-lg mt-1 flex-shrink-0">
-                  <Briefcase className="text-purple-400 h-6 w-6" />
+                  <exp.icon className="text-purple-400 h-6 w-6" />
                 </div>
                 <div className="flex-1">
                   <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 mb-1">


### PR DESCRIPTION
## Summary

- **About**: Updated hobbies line — "catching the latest Marvel movies" → "reading up about credit cards"
- **Experience icons**: Replaced the uniform briefcase icon with role-specific icons per card:
  - Expedia SWE II → `Globe` (travel/hospitality platform)
  - UW-Madison Tutor → `BookOpen` (education/teaching)
  - Expedia Intern → `BarChart2` (analytics dashboards)
  - Thomson Reuters → `Scale` (legal research product)

## Test plan

- [ ] About section shows "reading up about credit cards" in the hobbies line
- [ ] Each experience card shows its unique icon instead of a generic briefcase

https://claude.ai/code/session_01NJjGMfZGiQjf5z8NEQfjSB